### PR TITLE
解析less里包含@import后采用了当前路径，导致编译失败报错

### DIFF
--- a/lib/autoStatic.js
+++ b/lib/autoStatic.js
@@ -62,12 +62,15 @@ var AsyncProxy = require('./modules/AsyncProxy'),
 			var cb = cb || function(){};
 			fs.readFile(filepath, 'utf-8',function(err, data){//根据请求读取目录
 				if(err) return cb({msg:msg.resmsg.notFound, scode:500});//如果文件不存在，则cb(err)
-				less.render(data, function (err, css) {//开始编译less文件
+				var po = filepath.lastIndexOf('/')+1,
+					path = filepath.slice(po);
+				new(less.Parser)({
+					paths: [filepath.substr(0, po)],
+					filename: filepath
+				}).parse(data, function (err, tree) {//开始编译less文件
 					if(err) return cb({msg:msg.resmsg.lessError, scode:500});//如果编译出错，则cb(err)
-					var po = filepath.lastIndexOf('/')+1,
-						path = filepath.slice(po),
-						lesspath = filepath.replace(path, 'compile.'+path);//根据元有文件路径拼装成带less.为前缀的less css文件
-					fs.writeFile(lesspath, css, function(err){//根据 lesspath 生成编译好的css文件
+					var lesspath = filepath.replace(path, 'compile.'+path);//根据元有文件路径拼装成带less.为前缀的less css文件
+					fs.writeFile(lesspath, tree.toCSS({compress:true}), function(err){//根据 lesspath 生成编译好的css文件
 					if(err) return cb({msg:msg.resmsg.lessWriteError, scode:500});//如果写入出错
 					cb(null, lesspath);//执行回调 传参 lesspath
 					})


### PR DESCRIPTION
另外，我不是很明白，为什么你要用xx.less.css去命名css文件，而不在配置文件里写好对应的css解析器。
我觉得应该这样做，在开发模式下，存在对应的xxx.less文件就去编译之，反之发送xxx.css。当然这是我自己的想法。
